### PR TITLE
RM-51008 Release eva-catalog v2.0.1

### DIFF
--- a/client.alpha/project.clj
+++ b/client.alpha/project.clj
@@ -1,4 +1,4 @@
-(defproject com.workiva.eva.catalog/client.alpha "2.0.0"
+(defproject com.workiva.eva.catalog/client.alpha "2.0.1"
   :description "Client to the Eva Catalog Service"
   :plugins [[lein-modules "0.3.11"]
             [lein-cljfmt "0.6.4"]

--- a/common.alpha/project.clj
+++ b/common.alpha/project.clj
@@ -1,4 +1,4 @@
-(defproject com.workiva.eva.catalog/common.alpha "2.0.0"
+(defproject com.workiva.eva.catalog/common.alpha "2.0.1"
   :plugins [[lein-modules "0.3.11"]
             [lein-cljfmt "0.6.4"]
             [lein-codox "0.10.3"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.workiva.eva/catalog-parent "2.0.0"
+(defproject com.workiva.eva/catalog-parent "2.0.1"
   :plugins [[lein-modules "0.3.11"]
             [lein-cljfmt "0.6.4"]]
 

--- a/server.alpha/project.clj
+++ b/server.alpha/project.clj
@@ -1,4 +1,4 @@
-(defproject com.workiva.eva.catalog/server.alpha "2.0.0"
+(defproject com.workiva.eva.catalog/server.alpha "2.0.1"
   :plugins [[lein-modules "0.3.11"]
             [lein-ring "0.9.7"]
             [lein-cljfmt "0.6.4"]


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Fix deploy clojars command](https://github.com/Workiva/eva-catalog/pull/5)


Requested by: @tylerwilding-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/eva-catalog/compare/v2.0.0...Workiva:release_eva-catalog_v2.0.1
Diff Between Last Tag and New Tag: https://github.com/Workiva/eva-catalog/compare/v2.0.0...v2.0.1

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5890749770235904/logs/)