### PR TITLE
BUILDTOOLS-3493: Remove references to Shipyard

### DIFF
--- a/skynet.yaml
+++ b/skynet.yaml
@@ -12,5 +12,7 @@ artifacts:
  - logs/
 
 run:
+  on-pull-request: true
+  when-branch-name-is: .+
 
 timeout: moderate

--- a/skynet.yaml
+++ b/skynet.yaml
@@ -12,6 +12,5 @@ artifacts:
  - logs/
 
 run:
-  source: shipyard
 
 timeout: moderate


### PR DESCRIPTION

## Overview
BUILDTOOLS has identified that the last service dependent on Shipyard is an optional path in some skynet.yaml files. 
This PR will remove the offending line without having any affect on the functionality of Skynet. 

For any questions, please reach out to BUILDTOOLS in the #support-build chat in Slack. 


@tylerwilding-wk