### PR TITLE
RM-54675 Release eva-catalog v2.0.4

### DIFF
--- a/client.alpha/project.clj
+++ b/client.alpha/project.clj
@@ -1,4 +1,4 @@
-(defproject com.workiva.eva.catalog/client.alpha "2.0.3"
+(defproject com.workiva.eva.catalog/client.alpha "2.0.4"
   :description "Client to the Eva Catalog Service"
   :plugins [[lein-modules "0.3.11"]
             [lein-cljfmt "0.6.4"]

--- a/common.alpha/project.clj
+++ b/common.alpha/project.clj
@@ -1,4 +1,4 @@
-(defproject com.workiva.eva.catalog/common.alpha "2.0.3"
+(defproject com.workiva.eva.catalog/common.alpha "2.0.4"
   :plugins [[lein-modules "0.3.11"]
             [lein-cljfmt "0.6.4"]
             [lein-codox "0.10.3"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.workiva.eva/catalog-parent "2.0.3"
+(defproject com.workiva.eva/catalog-parent "2.0.4"
   :plugins [[lein-modules "0.3.11"]
             [lein-cljfmt "0.6.4"]]
 

--- a/server.alpha/project.clj
+++ b/server.alpha/project.clj
@@ -1,4 +1,4 @@
-(defproject com.workiva.eva.catalog/server.alpha "2.0.3"
+(defproject com.workiva.eva.catalog/server.alpha "2.0.4"
   :plugins [[lein-modules "0.3.11"]
             [lein-ring "0.9.7"]
             [lein-cljfmt "0.6.4"]


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Build uberjar.](https://github.com/Workiva/eva-catalog/pull/13)


Requested by: @erikpetersen-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/eva-catalog/compare/v2.0.3...Workiva:release_eva-catalog_v2.0.4
Diff Between Last Tag and New Tag: https://github.com/Workiva/eva-catalog/compare/v2.0.3...v2.0.4

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5890749770235904/logs/)